### PR TITLE
Process differently with status code when adding corkage store 

### DIFF
--- a/lib/screen/screen_corkage_store_form.dart
+++ b/lib/screen/screen_corkage_store_form.dart
@@ -61,7 +61,15 @@ class _CorkageStoreForm extends State<CorkageStoreForm> {
         body: json.encode(requestData));
 
     int statusCode = response.statusCode;
-    if (statusCode != 200) {
+    if (statusCode == 202) {
+      String msg = response.body.toString();
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(msg),
+        duration: Duration(milliseconds: 1000),
+      ));
+      print(response.body);
+    }
+    if (statusCode != 200 && statusCode != 202) {
       throw Exception('Failed to post Corkage Info');
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,6 +149,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   meta:
     dependency: transitive
     description:
@@ -230,7 +237,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
## 개요
콜키지 매장 등록 시 statusCode에 따라 처리하도록 변경

## 작업 사항
* 이미 등록된 콜키지 매장을 등록하려고 하는 경우 toast 메세지를 띄우도록 변경

## 변경 로직
* 기존 방식 : 콜키지 매장 등록 후 (POST) response 의 상태 코드가 200이 아닌 경우 에러 리턴
* 변경된 방식 : 200인 경우 기존대로 등록 성공, 202인 경우 사용자에게 이미 등록되었음을 알리는 toast message 띄움.